### PR TITLE
Suppress byte-compile warnings

### DIFF
--- a/auto-virtualenvwrapper.el
+++ b/auto-virtualenvwrapper.el
@@ -39,6 +39,9 @@
 (require 'virtualenvwrapper)
 (require 's)
 
+(declare-function projectile-project-name "projectile")
+(declare-function projectile-project-root "projectile")
+
 (defun auto-virtualenvwrapper-first-file-exists-p (filelist)
   "Select first file from the FILELIST which exists."
   (cl-loop for filename in (mapcar #'expand-file-name filelist)


### PR DESCRIPTION
This suppresses following warnings.

```
auto-virtualenvwrapper.el:156:1:Warning: the following functions are not known to be defined:
    projectile-project-name, projectile-project-root
```