### PR TITLE
Pipfile as project-root-files

### DIFF
--- a/auto-virtualenvwrapper.el
+++ b/auto-virtualenvwrapper.el
@@ -56,7 +56,7 @@
   :group 'auto-virtualenvwrapper)
 
 (defvar auto-virtualenvwrapper-project-root-files
-  '(".python-version" ".dir-locals.el" ".projectile" ".emacs-project" ".workon")
+  '(".python-version" ".dir-locals.el" ".projectile" ".emacs-project" ".workon" "Pipfile")
   "The presence of any file/directory in this list indicates a project root.")
 
 (defvar auto-virtualenvwrapper-verbose t


### PR DESCRIPTION
sometime it is desired to using PIpfile as project-root-files, more nature when you using pipenv.