### PR TITLE
Prefer project-root-traverse than project-root-vc

### DIFF
--- a/auto-virtualenvwrapper.el
+++ b/auto-virtualenvwrapper.el
@@ -103,8 +103,8 @@
   (or auto-virtualenvwrapper--project-root
       (setq auto-virtualenvwrapper--project-root
             (or (auto-virtualenvwrapper--project-root-projectile)
-                (auto-virtualenvwrapper--project-root-vc)
                 (auto-virtualenvwrapper--project-root-traverse)
+                (auto-virtualenvwrapper--project-root-vc)
                 "")))
   (when (eq auto-virtualenvwrapper--project-root "")
       (auto-virtualenvwrapper-message "Can't find project root"))


### PR DESCRIPTION
Could you change the order for finding project-root?
I have multiple Pipfiles in a git repository. I want to use as project-root the directory that Pipfile exists instead of git repository root.