### PR TITLE
Fix issue with activate causing error on missing directory

### DIFF
--- a/auto-virtualenvwrapper.el
+++ b/auto-virtualenvwrapper.el
@@ -117,10 +117,11 @@ invalid, because the buffer might be moved to another project.")
   "Tranvese parent directories looking for files in `auto-virtualenvwrapper-project-root-files' that indicates a root directory."
   (let ((dominating-file (locate-dominating-file default-directory
                            (lambda (dir)
-                             (cl-intersection
-                              auto-virtualenvwrapper-project-root-files
-                              (directory-files dir)
-                              :test 'string-equal)))))
+                             (and (file-directory-p dir)
+                                  (cl-intersection
+                                   auto-virtualenvwrapper-project-root-files
+                                   (directory-files dir)
+                                   :test 'string-equal))))))
     (when dominating-file
       (expand-file-name dominating-file))))
 


### PR DESCRIPTION
I've marked this a WIP because I haven't fully tested this yet (stay tuned), but it's important to share this fix, because it's a trivial issue to encounter, and can cause emacs to enter an unusable state.

How to trigger this issue
=========================

The easist way to trigger the bug this fixes:

1. create a subdir
2. creates files in the subdir
3. delete the subdir outside of emacs
4. Run trigger auto-virtualenvwrapper-activate on a buffer with its
   default-directory that of the now deleted directory.

Debugger Trace
==============

How the error looks in Emacs Debugger:

```
Debugger entered--Lisp error: (file-missing "Opening directory" "No such file or directory" "/home/winston/tmp/a")
  directory-files("~/tmp/a/")
  #f(compiled-function (dir) #<bytecode 0x17555e1>)("~/tmp/a/")
  locate-dominating-file("~/tmp/a/" #f(compiled-function (dir) #<bytecode 0x17555e1>))
  auto-virtualenvwrapper--project-root-traverse()
  auto-virtualenvwrapper--project-root()
  auto-virtualenvwrapper-find-virtualenv-path()
  auto-virtualenvwrapper-activate()
  run-hooks(focus-in-hook)
  handle-focus-in((focus-in #<frame Emacs *Ibuffer* [Fundamental] { *Ibuffer*, *Backtrace* } 0x7a7d600>))
  funcall-interactively(handle-focus-in (focus-in #<frame Emacs *Ibuffer* [Fundamental] { *Ibuffer*, *Backtrace* } 0x7a7d600>))
  call-interactively(handle-focus-in nil [(focus-in #<frame Emacs *Ibuffer* [Fundamental] { *Ibuffer*, *Backtrace* } 0x7a7d600>)])
  command-execute(handle-focus-in nil [(focus-in #<frame Emacs *Ibuffer* [Fundamental] { *Ibuffer*, *Backtrace* } 0x7a7d600>)] t)
```

(The source for the anonymous function the error occurs in):

```
byte code:
  args: (dir)
0       constant  cl-intersection
1       varref    auto-virtualenvwrapper-project-root-files
2       constant  directory-files
3       varref    dir
4       call      1
5       constant  :test
6       constant  string-equal
7       call      4
8       return
```

(As appears in the locate-dominating-file invocation.)

Impact
======

Using `(add-hook 'focus-in-hook #'auto-virtualenvwrapper-activate)`
may cause emacs to become unresponsive due, especially when using
ivy/swiper, yielding M-x not usable, and most prompts stop working.